### PR TITLE
Add diagram for Exercise 0.6: New note in single-page app

### DIFF
--- a/part0/part0_6_new_note_in_single_page_app_diagram.md
+++ b/part0/part0_6_new_note_in_single_page_app_diagram.md
@@ -1,0 +1,15 @@
+```mermaid
+sequenceDiagram
+    participant B as browser
+    participant S as server
+
+    Note right of B: The browser sends user input JSON data with the Content-Type: application/json.
+    Note right of B: {content: "IDDQD", date: "2024-05-25T21:17:22.801Z"}
+
+    B->>S: POST https://studies.cs.helsinki.fi/exampleapp/new_note_spa
+    activate S
+    S-->>B: HTTP status code 201 (Created)
+    deactivate S
+
+    Note right of B: The event handler creates the new note by calling notes.push(note)
+```


### PR DESCRIPTION
- Create a diagram depicting the user creating a new note using the single-page version of the notes app.
- Illustrate the user interaction and process flow at https://studies.cs.helsinki.fi/exampleapp/spa.