### PR TITLE
Display statistics only after feedback is gathered (exercise 1.9)

### DIFF
--- a/part1/unicafe/src/components/Statistics.jsx
+++ b/part1/unicafe/src/components/Statistics.jsx
@@ -1,19 +1,25 @@
 const Statistics = ({ good, neutral, bad }) => {
-  const total = good + neutral + bad;
-  const average = total === 0 ? 0 : (good - bad) / total;
-  const positivePercentage = total === 0 ? 0 : (good / total) * 100;
+  const total = good + neutral + bad
+  const average = total === 0 ? 0 : (good - bad) / total
+  const positivePercentage = total === 0 ? 0 : (good / total) * 100
 
   return (
     <div>
       <h1>Statistics</h1>
-      <div>Good {good}</div>
-      <div>Neutral {neutral}</div>
-      <div>Bad {bad}</div>
-      <div>All {total}</div>
-      <div>Average {average}</div>
-      <div>Positive {positivePercentage}%</div>
+      {total === 0 ? (
+        <p>No feedback given</p>
+      ) : (
+        <div>
+          <div>Good {good}</div>
+          <div>Neutral {neutral}</div>
+          <div>Bad {bad}</div>
+          <div>All {total}</div>
+          <div>Average {average}</div>
+          <div>Positive {positivePercentage}%</div>
+        </div>
+      )}
     </div>
-  );
-};
+  )
+}
 
-export default Statistics;
+export default Statistics


### PR DESCRIPTION
- Update application to show statistics only once feedback has been collected
- Display "No feedback given" when no feedback is present