### PR TITLE
Handle initial null state for persons (exercise 2.17)

### DIFF
--- a/part2/phonebook/src/App.jsx
+++ b/part2/phonebook/src/App.jsx
@@ -6,7 +6,7 @@ import personsService from './services/persons'
 import Notification from './components/Notification'
 
 const App = () => {
-  const [persons, setPersons] = useState([])
+  const [persons, setPersons] = useState(null)
 
   useEffect(() => {
     personsService.getAll()
@@ -120,6 +120,10 @@ const App = () => {
 
   const handleFilterChange = (event) => {
     setFilter(event.target.value)
+  }
+
+  if (persons === null) {
+    return null
   }
 
   const personsToShow = persons.filter(person =>


### PR DESCRIPTION
- Initialize persons state to null to denote uninitialized state
- Add conditional rendering to handle null state
  - Return null if persons state is null to prevent errors
- Follow the example in "Couple of important remarks" section
  - Ensure the application handles the initial state properly
  - Prevent errors like "Cannot read properties of null (reading 'map')"

This update improves the application's robustness by properly handling the initial state and preventing potential errors during data fetching.