### PR TITLE
Fix name display in delete notification

### DIFF
--- a/part2/phonebook/src/App.jsx
+++ b/part2/phonebook/src/App.jsx
@@ -93,8 +93,8 @@ const App = () => {
         .remove(id)
         .then(response => {
           setPersons(persons.filter(person => person.id !== id))
-          // console.log(`${response.data.name} deleted`)
-          setNotification({ message: `${response.data.name} deleted`, type: 'success' })
+          // console.log(`${person.name} deleted`)
+          setNotification({ message: `${person.name} deleted`, type: 'success' })
           setTimeout(() => {
             setNotification({ message: null, type: '' })
           }, 5000)


### PR DESCRIPTION
- Update notification logic to display the correct name when a person is deleted
  - Remove commented-out console.log statements
  - Ensure setNotification uses the correct person's name

This fix ensures that the notification message correctly displays the deleted person's name instead of undefined.